### PR TITLE
Some GUI polishing and tiny bug fix

### DIFF
--- a/bepdf/beos/FileInfoWindow.cpp
+++ b/bepdf/beos/FileInfoWindow.cpp
@@ -314,7 +314,7 @@ void FileInfoWindow::Refresh(BEntry *file, PDFDoc *doc, int page) {
 
 	mState = NORMAL;
 
-	BTabView *tabs = new BTabView("tabs");
+	BTabView *tabs = new BTabView("tabs", B_WIDTH_FROM_LABEL);
 
 	BGridView *document = new BGridView();
 
@@ -394,18 +394,14 @@ void FileInfoWindow::Refresh(BEntry *file, PDFDoc *doc, int page) {
 	mFontList->AddColumn(new BStringColumn(B_TRANSLATE("Embedded name"), 150.0,150.0,150.0,true),1);
 	mFontList->AddColumn(new BStringColumn(B_TRANSLATE("Type"), 80.0,80.0,80.0,true),2);
 
-	mFontsBorder = new BBox("border");
-	mFontsBorder->SetLabel(B_TRANSLATE("Fonts of this page"));
-	mFontsBorder->AddChild(mFontList);
-
 	mShowAllFonts = new BButton("showAllFonts", B_TRANSLATE("Show all fonts"), new BMessage(SHOW_ALL_FONTS_MSG));
 	mStop = new BButton("stop", B_TRANSLATE("Abort"), new BMessage(STOP_MSG));
 
-	BView *fonts = new BView(B_TRANSLATE("Fonts"), 0);
+	BView *fonts = new BView(B_TRANSLATE("Fonts of this page"), 0);
 
 	BLayoutBuilder::Group<>(fonts, B_VERTICAL)
 		.SetInsets(B_USE_WINDOW_INSETS)
-		.Add(mFontsBorder)
+		.Add(mFontList)
 		.AddGroup(B_HORIZONTAL)
 			.AddGlue()
 			.Add(mShowAllFonts)
@@ -413,11 +409,13 @@ void FileInfoWindow::Refresh(BEntry *file, PDFDoc *doc, int page) {
 		.End();
 
 	tabs->AddTab(fonts);
+	tabs->SetBorder(B_NO_BORDER);
 
 	mStop->SetEnabled(false);
 	QueryFonts(doc, page);
 
 	BLayoutBuilder::Group<>(this)
+		.SetInsets(0, B_USE_WINDOW_INSETS, 0, 0)
 		.Add(tabs);
 
 	Show();

--- a/bepdf/beos/FindTextWindow.cpp
+++ b/bepdf/beos/FindTextWindow.cpp
@@ -75,7 +75,8 @@ FindTextWindow::FindTextWindow(GlobalSettings *settings, const char *text,
 
 	BGroupLayout *optBox = BLayoutBuilder::Group<>(B_HORIZONTAL)
 		.SetInsets(B_USE_SMALL_SPACING)
-		.AddGroup(B_VERTICAL)
+		.AddGroup(B_VERTICAL, 0)
+			.SetInsets(B_USE_SMALL_INSETS, 0, B_USE_SMALL_INSETS, 0)
 			.Add(mIgnoreCase)
 			.Add(mBackward)
 		.End()

--- a/bepdf/beos/PDFWindow.cpp
+++ b/bepdf/beos/PDFWindow.cpp
@@ -643,14 +643,14 @@ BMenuBar* PDFWindow::BuildMenu()
 		menu = new BMenu ( B_TRANSLATE("Search") );
 			ADD_ITEM (menu, B_TRANSLATE("Find" B_UTF8_ELLIPSIS) , 'F', ( FIND_CMD));
 			menu->AddItem(new BMenuItem(B_TRANSLATE("Find next" B_UTF8_ELLIPSIS),
-				new BMessage(FIND_NEXT_CMD), 'F', B_SHIFT_KEY));
+				new BMessage(FIND_NEXT_CMD), 'G'));
 		menuBar->AddItem ( menu );
 
 		// Page
 		menu = new BMenu (B_TRANSLATE("Page"));
 			ADD_ITEM (menu, B_TRANSLATE("First"), 0,  (FIRST_PAGE_CMD));
 			ADD_ITEM (menu, B_TRANSLATE("Previous"), 0,  (PREVIOUS_PAGE_CMD));
-			ADD_ITEM (menu, B_TRANSLATE("Go to page"), 'G',  (GOTO_PAGE_MENU_CMD));
+			ADD_ITEM (menu, B_TRANSLATE("Jump to page"), 'J',  (GOTO_PAGE_MENU_CMD));
 			ADD_ITEM (menu, B_TRANSLATE("Next"), 0,  (NEXT_PAGE_CMD));
 			ADD_ITEM (menu, B_TRANSLATE("Last"), 0,  (LAST_PAGE_CMD));
 			ADD_SITEM(menu);
@@ -1184,7 +1184,7 @@ PDFWindow::MessageReceived(BMessage* message)
 		if (Lock()) {
 			mFindWindow = new FindTextWindow(gApp->GetSettings(), mFindText.String(), this);
 			Unlock();
-			mFindWindow->PostMessage('FIND');
+			mFindWindow->PostMessage('Find');
 		}
 		break;
 /*	case KEYBOARD_SHORTCUTS_CMD: {

--- a/bepdf/beos/PreferencesWindow.cpp
+++ b/bepdf/beos/PreferencesWindow.cpp
@@ -106,11 +106,13 @@ void PreferencesWindow::SetupView() {
 	BTextControl *author = new BTextControl("author", B_TRANSLATE("Author"),
 		settings->GetAuthor(), new BMessage(AUTHOR_CHANGED));
 
-	BGroupLayout *docBox = BLayoutBuilder::Group<>(B_VERTICAL)
-		.SetInsets(B_USE_SMALL_INSETS)
+	BGroupLayout *docBox = BLayoutBuilder::Group<>(B_VERTICAL, 0)
+		.SetInsets(B_USE_SMALL_INSETS, B_USE_SMALL_INSETS, B_USE_SMALL_INSETS, 0)
 		.Add(pageNumber)
 		.Add(windowPos)
+		.AddStrut(B_USE_ITEM_INSETS)
 		.Add(mOpenInWorkspace)
+		.AddStrut(B_USE_SMALL_INSETS)
 		.Add(author)
 		.AddGlue();
 
@@ -128,10 +130,11 @@ void PreferencesWindow::SetupView() {
 		new BMessage(QUASI_FULLSCREEN_MODE_ON));
 	docMore->SetValue(settings->GetQuasiFullscreenMode());
 
-	BGroupLayout *fsBox = BLayoutBuilder::Group<>(B_VERTICAL)
-		.SetInsets(B_USE_SMALL_INSETS)
+	BGroupLayout *fsBox = BLayoutBuilder::Group<>(B_VERTICAL, 0)
+		.SetInsets(B_USE_SMALL_INSETS, B_USE_SMALL_INSETS, B_USE_SMALL_INSETS, 0)
 		.Add(docOnly)
-		.Add(docMore);
+		.Add(docMore)
+		.AddStrut(B_USE_SMALL_INSETS);
 
 	BBox *fullscreen = new BBox("fullscreen");
 	fullscreen->SetLabel(B_TRANSLATE("Fullscreen mode"));
@@ -147,10 +150,11 @@ void PreferencesWindow::SetupView() {
 		new BMessage(FILLED_SELECTION_STROKED));
 	strokedRect->SetValue(!(settings->GetFilledSelection()));
 
-	BGroupLayout *rectBox = BLayoutBuilder::Group<>(B_VERTICAL)
-		.SetInsets(B_USE_SMALL_INSETS)
+	BGroupLayout *rectBox = BLayoutBuilder::Group<>(B_VERTICAL, 0)
+		.SetInsets(B_USE_SMALL_INSETS, B_USE_SMALL_INSETS, B_USE_SMALL_INSETS, 0)
 		.Add(filledRect)
-		.Add(strokedRect);
+		.Add(strokedRect)
+		.AddStrut(B_USE_SMALL_INSETS);
 
 	BBox *selection = new BBox("selection");
 	selection->SetLabel(B_TRANSLATE("Selection rectangle"));

--- a/bepdf/locales/de.catkeys
+++ b/bepdf/locales/de.catkeys
@@ -1,4 +1,4 @@
-1	German	application/x-vnd.mp-xpdf	3140665422
+1	German	application/x-vnd.mp-xpdf	1147160503
 Close	BepdfApplication		Schließen
 Show bookmarks	PDFWindow		Lesezeichen zeigen
 Go to page %d	PDFView		Zur Seite %d gehen
@@ -115,7 +115,6 @@ Forward in page history list	PDFWindow		Vorwärts in Seitenhistorie
 BePDF status	StatusWindow		BePDF Status
 Add new paragraph text annotation	PDFWindow		Anmerkung: Neuer Absatz
 User password	PasswordWindow		Benutzerkennwort
-Go to page	PDFWindow		Zur Seite gehen
 No title	OutlinesWindow		Kein Titel
 Fullscreen	PDFWindow		Vollbild
 Add sound annotation	PDFWindow		Anmerkung: Klang
@@ -132,7 +131,6 @@ Automatic	AnnotationWindow		Automatisch
 Print settings	PrintSettingsWindow		Druckereinstellungen
 Fonts of this page	FileInfoWindow		Schriften dieser Seite
 Print	PDFWindow		Drucken
-Fonts	FileInfoWindow		Schriften
 Issue tracker…	PDFWindow		Bugtracker…
 Font:	AnnotationWindow		Schrift:
 Restore page number	AnnotationWindow		Seitennummer wieder herstellen
@@ -163,6 +161,7 @@ Forward	PDFWindow		Vorwärts
 Allowed	FileInfoWindow		Gestattet
 Copy & paste:	FileInfoWindow		Kopieren & Einfügen:
 Hide side bar	PDFWindow		Seitenleiste ausblenden
+Jump to page	PDFWindow		Zu Seite gehen
 Version	BepdfApplication		Version
 Odd pages	PrintSettingsWindow		Ungerade Seiten
 Add line annotation	PDFWindow		Anmerkung: Linie

--- a/bepdf/locales/en.catkeys
+++ b/bepdf/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.mp-xpdf	3140665422
+1	English	application/x-vnd.mp-xpdf	1147160503
 Close	BepdfApplication		Close
 Show bookmarks	PDFWindow		Show bookmarks
 Go to page %d	PDFView		Go to page %d
@@ -115,7 +115,6 @@ Forward in page history list	PDFWindow		Forward in page history list
 BePDF status	StatusWindow		BePDF status
 Add new paragraph text annotation	PDFWindow		Add new paragraph text annotation
 User password	PasswordWindow		User password
-Go to page	PDFWindow		Go to page
 No title	OutlinesWindow		No title
 Fullscreen	PDFWindow		Fullscreen
 Add sound annotation	PDFWindow		Add sound annotation
@@ -132,7 +131,6 @@ Automatic	AnnotationWindow		Automatic
 Print settings	PrintSettingsWindow		Print settings
 Fonts of this page	FileInfoWindow		Fonts of this page
 Print	PDFWindow		Print
-Fonts	FileInfoWindow		Fonts
 Issue tracker…	PDFWindow		Issue tracker…
 Font:	AnnotationWindow		Font:
 Restore page number	AnnotationWindow		Restore page number
@@ -163,6 +161,7 @@ Forward	PDFWindow		Forward
 Allowed	FileInfoWindow		Allowed
 Copy & paste:	FileInfoWindow		Copy & paste:
 Hide side bar	PDFWindow		Hide side bar
+Jump to page	PDFWindow		Jump to page
 Version	BepdfApplication		Version
 Odd pages	PrintSettingsWindow		Odd pages
 Add line annotation	PDFWindow		Add line annotation


### PR DESCRIPTION
* Polished the layout of preference, file info and find panel, mostly
  with regard to padding.
* Changed shortcut of "Find next" to ALT+G, renamed "Go to page" to
  "Jump to page" and assign ALT+J to it (was ALT+G).
* Updated de and en catkeys accordingly.
* Corrected message to Find window in case of a "Find next". Before,
  there wouldn't be an automatic next search and the result would be
  identical to a normal "Find" invokation.
  Ideally, the Find window wouldn't be shown when "Find next" is invoked.
  I tried adding a mFindWindow->PostMessage('QTrq') to quit the Find window
  immediately, but that would show the window for a milisecond, because
  it would be a very dirty hack...