### PR TITLE
Fixes use-after-free memory error reported Clang Static Analyzer

### DIFF
--- a/bepdf/beos/utils/Thread.cpp
+++ b/bepdf/beos/utils/Thread.cpp
@@ -40,11 +40,13 @@ void Thread::SetPriority(int32 priority) {
 }
 	
 status_t Thread::Resume() {
-	if (InitCheck() != B_OK) {
+	status_t result = InitCheck();
+	if (result != B_OK) {
 		delete this;
+		return result;
 	}
 	
-	status_t result = resume_thread(mThreadId);
+	result = resume_thread(mThreadId);
 	if (result != B_OK) {
 		delete this;
 	}


### PR DESCRIPTION
Fixes part of issue #80: the only bug found in BePDF.

I will work on fixing some of the 79 bugs found in xpdf. 