### PR TITLE
Explicitly link against libshared

### DIFF
--- a/bepdf/Makefile
+++ b/bepdf/Makefile
@@ -93,7 +93,7 @@ RSRCS =
 #	- 	if your library does not follow the standard library naming scheme,
 #		you need to specify the path to the library and it's name.
 #		(e.g. for mylib.a, specify "mylib.a" or "path/mylib.a")
-LIBS = be textencoding columnlistview tracker translation localestub \
+LIBS = shared be textencoding columnlistview tracker translation localestub \
 	../xpdf/libxpdf.a $(STDCPPLIBS)
 
 #	Specify additional paths to directories following the standard libXXX.so


### PR DESCRIPTION
Needed after hrev56577, and necessary to update BePDF's recipe at Haikuports (to make it use latest git version).

That change to using newest git version is necessary due to the change from freetype_config (not available anymore) to pkg-config.