### PR TITLE
#115 fixed bookmark treeview, and more robust saving of user bookmarks

### DIFF
--- a/bepdf/beos/PDFWindow.cpp
+++ b/bepdf/beos/PDFWindow.cpp
@@ -499,11 +499,11 @@ void PDFWindow::UpdateInputEnabler()
 		fMenuBar->FindItem(SELECT_ALL_CMD)->SetEnabled(okToCopy);
 		fMenuBar->FindItem(SELECT_NONE_CMD)->SetEnabled(okToCopy);
 
-		bool hasBookmark = mOutlinesView->HasUserBookmark(page);
-		bool selected    = hasBookmark && mOutlinesView->IsUserBMSelected();
-		fMenuBar->FindItem(ADD_BOOKMARK_CMD)->SetEnabled(!hasBookmark);
-		fMenuBar->FindItem(EDIT_BOOKMARK_CMD)->SetEnabled(selected);
-		fMenuBar->FindItem(DELETE_BOOKMARK_CMD)->SetEnabled(selected);
+		bool hasUserBookmark = mOutlinesView->HasUserBookmark(page);
+		bool selected    = hasUserBookmark && mOutlinesView->IsUserBMSelected();
+		fMenuBar->FindItem(ADD_USER_BOOKMARK_CMD)->SetEnabled(!hasUserBookmark);
+		fMenuBar->FindItem(EDIT_USER_BOOKMARK_CMD)->SetEnabled(selected);
+		fMenuBar->FindItem(DELETE_USER_BOOKMARK_CMD)->SetEnabled(selected);
 
 		// Annotation
 		bool editAnnot = mMainView->EditingAnnot();
@@ -637,9 +637,9 @@ BMenuBar* PDFWindow::BuildMenu()
 		.End()
 
 		.AddMenu(B_TRANSLATE("Bookmark"))
-			.AddItem(B_TRANSLATE("Add"), ADD_BOOKMARK_CMD)
-			.AddItem(B_TRANSLATE("Delete"), DELETE_BOOKMARK_CMD)
-			.AddItem(B_TRANSLATE("Edit"), EDIT_BOOKMARK_CMD)
+			.AddItem(B_TRANSLATE("Add"), ADD_USER_BOOKMARK_CMD)
+			.AddItem(B_TRANSLATE("Delete"), DELETE_USER_BOOKMARK_CMD)
+			.AddItem(B_TRANSLATE("Edit"), EDIT_USER_BOOKMARK_CMD)
 		.End()
 
 		.AddMenu(B_TRANSLATE("Help"))
@@ -1256,11 +1256,11 @@ PDFWindow::MessageReceived(BMessage* message)
 		break;
 	case FULL_SCREEN_CMD: OnFullScreen();
 		break;
-	case ADD_BOOKMARK_CMD: AddBookmark();
+	case ADD_USER_BOOKMARK_CMD: AddUserBookmark();
 		break;
-	case DELETE_BOOKMARK_CMD: DeleteBookmark();
+	case DELETE_USER_BOOKMARK_CMD: DeleteUserBookmark();
 		break;
-	case EDIT_BOOKMARK_CMD: EditBookmark();
+	case EDIT_USER_BOOKMARK_CMD: EditUserBookmark();
 		break;
 	case SHOW_TRACER_CMD: OutputTracer::ShowWindow(gApp->GetSettings());
 		break;
@@ -1688,26 +1688,42 @@ void PDFWindow::WorkspaceActivated(int32 workspace, bool active) {
 
 // #pragma mark - User-defined bookmarks
 
-void PDFWindow::AddBookmark()
+void PDFWindow::AddUserBookmark()
 {
 	char buffer[256];
 	sprintf(buffer, B_TRANSLATE("Page %d"), mMainView->Page());
 	new BookmarkWindow(mMainView->Page(), buffer, BRect(30, 30, 300, 200), this);
 }
 
-void PDFWindow::DeleteBookmark() {
+void PDFWindow::DeleteUserBookmark() {
 	mOutlinesView->RemoveUserBookmark(mMainView->Page());
 	SaveUserBookmarks();
 	UpdateInputEnabler();
 }
 
-void PDFWindow::EditBookmark() {
+void PDFWindow::EditUserBookmark() {
 	const char *label = mOutlinesView->GetUserBMLabel(mMainView->Page());
 	if (label) {
 		new BookmarkWindow(mMainView->Page(), label, BRect(30, 30, 300, 200), this);
 	} else {
 		// should not reach here
 	}
+}
+
+void PDFWindow::SaveUserBookmarks()
+{
+	if (mCurrentFile.InitCheck() != B_OK)
+		return;
+	
+	BMessage bm;
+	if (!mOutlinesView->GetBookmarks(&bm))
+		return;
+	
+	entry_ref cur_ref;
+	mCurrentFile.GetRef(&cur_ref);
+	
+	mFileAttributes.SetBookmarks(&bm);
+	mFileAttributes.Write(&cur_ref, gApp->GetSettings());
 }
 
 // #pragma mark - Annotations
@@ -1976,20 +1992,4 @@ void PDFWindow::ReleaseAnnotationButton() {
 		mPressedAnnotationButton->SetValue(B_CONTROL_OFF);
 		mPressedAnnotationButton = NULL;
 	}
-}
-
-void PDFWindow::SaveUserBookmarks()
-{
-	if (mCurrentFile.InitCheck() != B_OK)
-		return;
-	
-	BMessage bm;
-	if (!mOutlinesView->GetBookmarks(&bm))
-		return;
-	
-	entry_ref cur_ref;
-	mCurrentFile.GetRef(&cur_ref);
-	
-	mFileAttributes.SetBookmarks(&bm);
-	mFileAttributes.Write(&cur_ref, gApp->GetSettings());
 }

--- a/bepdf/beos/PDFWindow.cpp
+++ b/bepdf/beos/PDFWindow.cpp
@@ -310,9 +310,6 @@ void PDFWindow::StoreFileAttributes() {
 		entry_ref cur_ref;
 		if (mCurrentFile.InitCheck() == B_OK) {
 			mCurrentFile.GetRef(&cur_ref);
-			BMessage bm;
-			if (mOutlinesView->GetBookmarks(&bm))
-				mFileAttributes.SetBookmarks(&bm);
 			mFileAttributes.Write(&cur_ref, gApp->GetSettings());
 		}
 		Unlock();
@@ -1434,6 +1431,7 @@ PDFWindow::MessageReceived(BMessage* message)
 			if (message->FindString("label", &label) == B_OK &&
 			    message->FindInt32("pageNum", &pageNum) == B_OK) {
 				mOutlinesView->AddUserBookmark(pageNum, label.String());
+				SaveUserBookmarks();
 				UpdateInputEnabler();
 			}
 		}
@@ -1597,10 +1595,10 @@ PDFWindow::ShowLeftPanel(int panel)
 	if (mLayerView->CardLayout()->VisibleIndex() != panel) {
 		gApp->GetSettings()->SetLeftPanel(panel);
 		mLayerView->CardLayout()->SetVisibleItem(panel);
-		if (panel == BOOKMARKS_PANEL) {
-			ActivateOutlines();
-		}
 	}
+	if (panel == BOOKMARKS_PANEL) {
+		ActivateOutlines();
+	}	
 	UpdateInputEnabler();
 }
 
@@ -1699,6 +1697,7 @@ void PDFWindow::AddBookmark()
 
 void PDFWindow::DeleteBookmark() {
 	mOutlinesView->RemoveUserBookmark(mMainView->Page());
+	SaveUserBookmarks();
 	UpdateInputEnabler();
 }
 
@@ -1977,4 +1976,20 @@ void PDFWindow::ReleaseAnnotationButton() {
 		mPressedAnnotationButton->SetValue(B_CONTROL_OFF);
 		mPressedAnnotationButton = NULL;
 	}
+}
+
+void PDFWindow::SaveUserBookmarks()
+{
+	if (mCurrentFile.InitCheck() != B_OK)
+		return;
+	
+	BMessage bm;
+	if (!mOutlinesView->GetBookmarks(&bm))
+		return;
+	
+	entry_ref cur_ref;
+	mCurrentFile.GetRef(&cur_ref);
+	
+	mFileAttributes.SetBookmarks(&bm);
+	mFileAttributes.Write(&cur_ref, gApp->GetSettings());
 }

--- a/bepdf/beos/PDFWindow.cpp
+++ b/bepdf/beos/PDFWindow.cpp
@@ -976,7 +976,7 @@ PDFWindow::SetPage(int32 page) {
     if (page > mPagesView->CountItems()) {
         page = mPagesView->CountItems();
     }
-	snprintf (pageStr, sizeof (pageStr), "%d", page);
+	snprintf (pageStr, sizeof (pageStr), "%d" B_PRId32, page);
 	mPageNumberItem->SetText (pageStr);
 	mPagesView->Select(page-1);
 	mPagesView->ScrollToSelection();
@@ -986,7 +986,7 @@ PDFWindow::SetPage(int32 page) {
 void
 PDFWindow::MessageReceived(BMessage* message)
 {
-	int page;
+	int32 page;
 	const char *text;
 
 	if (CancelCommand(message))

--- a/bepdf/beos/PDFWindow.h
+++ b/bepdf/beos/PDFWindow.h
@@ -159,9 +159,9 @@ public:
 		FIND_NEXT_CMD,
 
 		// User defined bookmarks
-		ADD_BOOKMARK_CMD,
-		DELETE_BOOKMARK_CMD,
-		EDIT_BOOKMARK_CMD,
+		ADD_USER_BOOKMARK_CMD,
+		DELETE_USER_BOOKMARK_CMD,
+		EDIT_USER_BOOKMARK_CMD,
 
 		// Help
 		HELP_CMD,
@@ -344,9 +344,9 @@ protected:
 	void OnFullScreen();
 
 	// User defined bookmarks
-	void AddBookmark();
-	void DeleteBookmark();
-	void EditBookmark();
+	void AddUserBookmark();
+	void DeleteUserBookmark();
+	void EditUserBookmark();
 	void SaveUserBookmarks();
 
 	// Annotations

--- a/bepdf/beos/PDFWindow.h
+++ b/bepdf/beos/PDFWindow.h
@@ -347,6 +347,7 @@ protected:
 	void AddBookmark();
 	void DeleteBookmark();
 	void EditBookmark();
+	void SaveUserBookmarks();
 
 	// Annotations
 	void PressAnnotationButton();


### PR DESCRIPTION
Fix the bookmark treeview issue #115 . It was just trapped in an IF statement that it didn't need to be in.

Also made the saving of user bookmarks more robust. It will save the attributes when a user bookmark is added or deleted, instead of doing it on QuitReqested. That way if the app crashed you won't lose changes made to user bookmarks.